### PR TITLE
Add multipleMax setting

### DIFF
--- a/widget/index.js
+++ b/widget/index.js
@@ -53,6 +53,7 @@ JFCustomWidget.subscribe('ready', function(data) {
 		locale: JFCustomWidget.getWidgetSetting('locale') || 'en',
 		imagesOnly: (JFCustomWidget.getWidgetSetting('imagesOnly') == 'Yes'),
 		multiple: isMultiple,
+		multipleMax: JFCustomWidget.getWidgetSetting('multipleMax'),
 		previewStep: (JFCustomWidget.getWidgetSetting('previewStep') == 'Yes'),
 		crop: cropOption(
 			JFCustomWidget.getWidgetSetting('crop'),


### PR DESCRIPTION
Turning on the "multiple" setting in the JotForm widget opens the file upload functionality to user abuse unless a maximum number of files can also be specified.  Pulling this change along with making the appropriate changes on the JotForm end to add the multipleMax setting for the widget will resolve this issue.