### PR TITLE
Update index.js

### DIFF
--- a/widget/index.js
+++ b/widget/index.js
@@ -107,11 +107,14 @@ JFCustomWidget.subscribe('ready', function(data) {
 
 	widget.onChange(function(file) {
 		files = []
+		var fileInfos = []
 		var uploadedFiles = file.files ? file.files() : [file]
 
 		uploadedFiles.forEach(function(uploadedFile) {
 			uploadedFile.done(function(fileInfo) {
+				fileInfos.push(fileInfo.name)
 				files.push(fileInfo.cdnUrl)
+				JFCustomWidget.sendData({value:fileInfos.join(',')})
 			})
 		})
 	})


### PR DESCRIPTION
There is a bug regarding uploadcare widget. User wants to check his/her uploaded files in review page. In order to do that, uploadcare should pass file's name to Jotform.
You can check the [ticket in here](https://www.jotform.com/answers/1307177-New-form-layout-Uploadcare-widget-is-not-retaining-uploaded-file).