### PR TITLE
Fix default empty file name

### DIFF
--- a/widget/index.js
+++ b/widget/index.js
@@ -37,7 +37,7 @@ function sanitizeFileName(fileName) {
   var name = fileName.substring(0, fileName.length - extension.length)
   name = name.replace(regexp, '')
   if (!name.length) {
-  	return 'noroot' + '.' + extension
+  	return 'file' + '.' + extension
   }
   return name + '.' + extension
 }


### PR DESCRIPTION
If a user sets to add a file name to the output URL and after sanitizing all characters are removed, the "noroot" name will lead to downloading the file with the original name, which may cause issues on the user's system. Using the "file" name instead will lead to downloading the file with the name "file.[ext]".
